### PR TITLE
[VEN-2203] Add query hints to the latest dbt-sqlserver version

### DIFF
--- a/dbt/include/sqlserver/macros/materializations/models/table/create_table_as.sql
+++ b/dbt/include/sqlserver/macros/materializations/models/table/create_table_as.sql
@@ -2,6 +2,7 @@
    {#- TODO: add contracts here when in dbt 1.5 -#}
    {%- set sql_header = config.get('sql_header', none) -%}
    {%- set as_columnstore = config.get('as_columnstore', default=true) -%}
+   {%- set query_hints = config.get('query_hints', default=None) -%}
    {%- set temp_view_sql = sql.replace("'", "''") -%}
    {%- set tmp_relation = relation.incorporate(
         path={"identifier": relation.identifier.replace("#", "") ~ '_temp_view'},
@@ -23,6 +24,7 @@
    SELECT *
    INTO {{ relation.include(database=False, schema=(not temporary))  }}
    FROM {{ tmp_relation }}
+   {% if query_hints %}OPTION ({{ query_hints }}){% endif %}
 
    -- drop temp view
    {{ sqlserver__drop_relation_script(tmp_relation) }}


### PR DESCRIPTION
After the change query hints can be added again, e.g. 
`{{ config(query_hints='MAXDOP 2') }}` 

will be rendered as:
![image](https://github.com/dbt-msft/dbt-sqlserver/assets/2611145/9f8c0365-ab93-45ff-87ce-a356a0fa92f4)
